### PR TITLE
build.properties to Processing 3.2.3 and Java 8

### DIFF
--- a/resources/build.properties
+++ b/resources/build.properties
@@ -48,7 +48,7 @@ classpath.libraries.location=${sketchbook.location}/libraries
 
 # Set the java version that should be used to compile your Library.
 
-java.target.version=1.7
+java.target.version=1.8
 
 
 # Set the description of the Ant build.xml file.
@@ -155,17 +155,18 @@ compatible.maxRevision=0
 # against. This information is only used in the generated webpage.
 
 tested.platform=osx,windows
-tested.processingVersion=3.0
+tested.processingVersion=3.2.3
 
 
 # Additional information for the generated webpage.
 
-library.copyright=(c) 2015
+library.copyright=(c) 2016
 library.dependencies=?
 library.keywords=?
 
 
 # Include javadoc references into your project's javadocs.
 
-javadoc.java.href=http://docs.oracle.com/javase/7/docs/api/
+#javadoc.java.href=http://docs.oracle.com/javase/7/docs/api/
+javadoc.java.href=http://docs.oracle.com/javase/8/docs/api/
 javadoc.processing.href=http://processing.org/reference/javadoc/core/


### PR DESCRIPTION
Updated default settings for new Processing releases, pointed at javadoc at Java 8 by default.